### PR TITLE
Aviso sobre o SSDT-CPUR na instalação/update para o Sequoia em placas geração 500

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ These files are **MUST** be included in your EFI's ACPI directory. We recommend 
 SSDT|Description
 :----|:----
 SSDT-EC-USBX|[Manual](https://dortania.github.io/Getting-Started-With-ACPI/Universal/ec-methods/manual.html) \| [Prebuilt](https://github.com/dortania/Getting-Started-With-ACPI/raw/master/extra-files/compiled/SSDT-EC-USBX-DESKTOP.aml) \| [Details](https://dortania.github.io/Getting-Started-With-ACPI/Universal/ec-fix.html)
-SSDT-CPUR|[Prebuilt](https://github.com/dortania/Getting-Started-With-ACPI/raw/master/extra-files/compiled/SSDT-CPUR.aml) <br> *Only for B550 and A520*
+SSDT-CPUR|[Prebuilt](https://github.com/dortania/Getting-Started-With-ACPI/raw/master/extra-files/compiled/SSDT-CPUR.aml) <br> *Only for B550 and A520* <br>⚠️ **Warning:** If you're experiencing issues updating to **Sequoia+**, try removing this SSDT.
 
 ### Dumping your DSDT in Windows Environment
 [Download iASL Compiler ACPI Tools](https://www.intel.com/content/www/us/en/download/774881/acpi-component-architecture-downloads-windows-binary-tools.html)


### PR DESCRIPTION
Eu e outro membro passamos pelo mesmo problema, ao remover esse SSDT deu tudo certo, créditos também ao membro que ajudou: @wonkabb